### PR TITLE
`azurerm_api_management_backend` add test for service_fabric_cluster.server_x509_name.issuer_certificate_thumbprint/name

### DIFF
--- a/internal/services/apimanagement/api_management_backend_resource_test.go
+++ b/internal/services/apimanagement/api_management_backend_resource_test.go
@@ -143,6 +143,21 @@ func TestAccApiManagementBackend_serviceFabric(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementBackend_serviceFabricCluster(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_backend", "test")
+	r := ApiManagementAuthorizationBackendResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceFabricCluster(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApiManagementBackend_serviceFabricClientCertificateId(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_backend", "test")
 	r := ApiManagementAuthorizationBackendResource{}
@@ -336,6 +351,39 @@ resource "azurerm_api_management_backend" "test" {
       azurerm_api_management_certificate.test.thumbprint,
       azurerm_api_management_certificate.test.thumbprint,
     ]
+  }
+}
+`, r.template(data, "sf"), data.RandomInteger)
+}
+
+func (r ApiManagementAuthorizationBackendResource) serviceFabricCluster(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_certificate" "test" {
+  name                = "example-cert"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  data                = filebase64("testdata/keyvaultcert.pfx")
+  password            = ""
+}
+
+resource "azurerm_api_management_backend" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  protocol            = "http"
+  url                 = "fabric:/mytestapp/acctest"
+  service_fabric_cluster {
+    client_certificate_thumbprint = azurerm_api_management_certificate.test.thumbprint
+    server_x509_name {
+      name                          = "test"
+      issuer_certificate_thumbprint = azurerm_api_management_certificate.test.thumbprint
+    }
+    management_endpoints = [
+      "https://acctestsf.com",
+    ]
+    max_partition_resolution_retries = 5
   }
 }
 `, r.template(data, "sf"), data.RandomInteger)

--- a/internal/services/apimanagement/api_management_backend_resource_test.go
+++ b/internal/services/apimanagement/api_management_backend_resource_test.go
@@ -361,7 +361,7 @@ func (r ApiManagementAuthorizationBackendResource) serviceFabricCluster(data acc
 %s
 
 resource "azurerm_api_management_certificate" "test" {
-  name                = "example-cert"
+  name                = "acctest-cert-%[2]d"
   api_management_name = azurerm_api_management.test.name
   resource_group_name = azurerm_resource_group.test.name
   data                = filebase64("testdata/keyvaultcert.pfx")
@@ -369,7 +369,7 @@ resource "azurerm_api_management_certificate" "test" {
 }
 
 resource "azurerm_api_management_backend" "test" {
-  name                = "acctestapi-%d"
+  name                = "acctestapi-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   api_management_name = azurerm_api_management.test.name
   protocol            = "http"


### PR DESCRIPTION
<img width="705" alt="service1" src="https://user-images.githubusercontent.com/96756505/162878403-fe3488ec-fe8a-41ec-9f3f-218242c54052.png">
